### PR TITLE
Add more ways of getting info from the xml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,10 +833,10 @@ Let's say we have a plural resource that should look like this:
 
 ```xml
     <string-plural id="unique">
-        <singular>This is the singular string</singular>
-        <double>This is the dual string</double>
+        <one>This is the singular string</one>
+        <two>This is the dual string</two>
         <many>This is the many plural string</many>
-        <plural>This is the plural string</plural>
+        <other>This is the plural string</other>
     </string-plural>
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Example configuration:
                     "method": "sparse",
                     "template": "config/config_[localeUnder].xml",
                     "localeMap": {
-                        "de-DE": "de", 
-                        "fr-FR": "fr", 
+                        "de-DE": "de",
+                        "fr-FR": "fr",
                         "ja-JP": "ja"
                     }
                 },

--- a/README.md
+++ b/README.md
@@ -1134,6 +1134,7 @@ file for more details.
       file, even if it does not exist in the source file. This
       allows for localization of empty strings or missing source
       strings.
+- fixed android resource schema file which was missing from the package
 
 ### v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ used within the json property:
       white label app. Each resource produced from the source file
       will have the given flavor. If not specified, there is no
       flavor attribute for the resources.
+    - localeMap: an output locale map that specifies the mapping
+      between locales that are used internally in the plugin, and the
+      output locale that should be used for constructing
+      the file name of output files. If a locale does not appear in
+      the mapping, it will not be mapped. That is, the original locale
+      will be used to construct the output file name.
     - template: a path template to use to generate the path to
       the translated
       output files. The template replaces strings in square brackets
@@ -217,7 +223,12 @@ Example configuration:
                 "**/config.xml": {
                     "schema": "http://www.lge.com/xml/config",
                     "method": "sparse",
-                    "template": "config/config_[localeUnder].xml"
+                    "template": "config/config_[localeUnder].xml",
+                    "localeMap": {
+                        "de-DE": "de", 
+                        "fr-FR": "fr", 
+                        "ja-JP": "ja"
+                    }
                 },
                 "customer1/src/**/strings.xml": {
                     "schema": "http://www.mycompany.com/xml/strings",
@@ -239,7 +250,9 @@ In the second part of the example, any `config.xml` file will be parsed with
 the schema `http://www.mycompany.com/xml/config`. Because the method is
 `sparse`, only the parts of the XML file that have translated strings in them will
 appear in the output config files. The output file is sent to the `config`
-directory.
+directory, and the locale used to construct the file name goes through the
+locale map first. That is, if you localized to the locale "de-DE", the locale
+will be mapped to "de" and the file name will come out as "config/config_de.xml"
 
 In the third part of the example, any `strings.xml` file that appears in
 the `src` directory will be parsed with the schema
@@ -1135,6 +1148,7 @@ file for more details.
       allows for localization of empty strings or missing source
       strings.
 - fixed android resource schema file which was missing from the package
+- added localeMap to the configuration of a mapping
 
 ### v1.0.0
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ used within the json property:
           include localized strings
         - resource: write out a resource file format with the
           translations in it
+    - flavor: the flavor attribute to use for Android resource files.
+      The flavor usually applies to all resources in a particular
+      subdirectory, and corresponds to a particular customer for a
+      white label app. Each resource produced from the source file
+      will have the given flavor. If not specified, there is no
+      flavor attribute for the resources.
     - template: a path template to use to generate the path to
       the translated
       output files. The template replaces strings in square brackets
@@ -213,9 +219,10 @@ Example configuration:
                     "method": "sparse",
                     "template": "config/config_[localeUnder].xml"
                 },
-                "src/**/strings.xml": {
+                "customer1/src/**/strings.xml": {
                     "schema": "http://www.mycompany.com/xml/strings",
                     "method": "copy",
+                    "flavor": "customer1",
                     "template": "[dir]/strings.[locale].xml"
                 }
             }
@@ -240,7 +247,8 @@ the `src` directory will be parsed with the schema
 the parts that were not localized,
 will be sent to the same directory as the source file. However, the
 localized file name will also contain the name of the locale to distinguish
-it from the source file.
+it from the source file. Also, every resource in the strings.xml file will have
+the Android flavor "customer1".
 
 If the name of the localized file that the template produces is the same as
 the source file name, this plugin will throw an exception, the file will not
@@ -372,6 +380,8 @@ XML:
 - "comment" - a comment for the translator to give more context
 - "locale" - the source locale of this resource
 - "category" - the plural category for a plural resource
+- "context" - the context field for this resource
+- "formatted" - for Android resources, the formatted attribute of a resource
 
 #### Element Parts
 
@@ -385,6 +395,9 @@ name of all the elements in the tree above the current element
 plus the name of the current element, all separated by slashes. This
 is similar to an xpath selector without any predicates or wildcards
 in it.
+- "_pathname" - The full path name of the file from the root of the project
+to the current file
+- "_basename" - The basename of the current file without the extension
 
 #### Assigning Element Parts to Resource Fields
 
@@ -812,6 +825,9 @@ values from the resource. Here is a table of the replacement values:
 | _category | The category of the translation |
 | _locale | The locale specifier for the translation |
 | _comment | The translator's comment for the resource |
+| _context | The context attribute for the resource |
+| _flavor  | The flavor attribute for the resource (Android) |
+| _formatted  | The formatted attribute for the resource (Android) |
 
 Let's say we have a plural resource that should look like this:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ used within the json property:
   similar to the the `includes` and `excludes` section of a
   `project.json` file. The value of that mapping is an object that
   can contain the following properties:
-    - schema: schema to use with that matcher. The schema is 
+    - schema: schema to use with that matcher. The schema is
       specified using the `$id` of one of the schemas loaded in the
       `schemas` property above. The default schema is "properties-schema"
       which is given in the previous section.
@@ -180,7 +180,7 @@ used within the json property:
         - [dir] the original directory where the matched source file
           came from. This is given as a directory that is relative
           to the root of the project. eg. "foo/bar/strings.xml" -> "foo/bar"
-        - [filename] the file name of the matching file. 
+        - [filename] the file name of the matching file.
           eg. "foo/bar/strings.xml" -> "strings.xml"
         - [basename] the basename of the matching file without any extension
           eg. "foo/bar/strings.xml" -> "strings"
@@ -529,7 +529,7 @@ in the original XML file.
 
 When the `localizable` keyword is given for an object type, that object
 may encode a plural string. Plurals are not possible if the JSON schema
-for the current element is a primitive type like string or number. 
+for the current element is a primitive type like string or number.
 The `localizableType` keyword should contain a type property with
 the value "plural" to specify that.
 
@@ -1118,6 +1118,22 @@ This plugin is license under Apache2. See the [LICENSE](./LICENSE)
 file for more details.
 
 ## Release Notes
+
+### v1.1.0
+
+- Add support for new replacements and tags
+    - In parsing the resources, you can now extracted the
+      "formatted", "context", and the "flavor" attributes for a resource.
+    - In creating a plural template, you can now use those three
+      attributes.
+    - When getting the value of an attribute, you can now use the
+      \_pathname and \_basename values, which will convert into the full
+      path name of the file, and the base name of the file.
+- Make sure required properties exist in the localization
+    - If a property is required, it should exist in the localized
+      file, even if it does not exist in the source file. This
+      allows for localization of empty strings or missing source
+      strings.
 
 ### v1.0.0
 

--- a/XmlFile.js
+++ b/XmlFile.js
@@ -262,7 +262,12 @@ XmlFile.prototype.getValue = function(value, xml, ref, element) {
         case "_pathname":
             return this.pathName;
         case "_basename":
-            return path.basename(this.pathName, ".xml");
+            if (this.pathName) {
+                var base = path.basename(this.pathName);
+                var firstdot = base.indexOf(".");
+                return firstdot > -1 ? base.substring(0, firstdot) : base;
+            }
+            return undefined;
     }
     return value;
 }

--- a/XmlFile.js
+++ b/XmlFile.js
@@ -333,7 +333,7 @@ XmlFile.prototype.hydrateResourceInfo = function(resourceInfo, schema, text, key
             } else if (field === "locale") {
                 var l = new Locale(convertValueToType(value, schema.type));
                 resourceInfo[field] = l.getSpec();
-            } else if (value) {
+            } else if (typeof(value) !== 'undefined') {
                 resourceInfo[field] = convertValueToType(value, schema.type);
             }
         }

--- a/XmlFile.js
+++ b/XmlFile.js
@@ -325,6 +325,9 @@ XmlFile.prototype.hydrateResourceInfo = function(resourceInfo, schema, text, key
                         resourceInfo.source = value || "";
                         break;
                 }
+            } else if (field === "locale") {
+                var l = new Locale(convertValueToType(value, schema.type));
+                resourceInfo[field] = l.getSpec();
             } else if (value) {
                 resourceInfo[field] = convertValueToType(value, schema.type);
             }

--- a/XmlFile.js
+++ b/XmlFile.js
@@ -875,9 +875,14 @@ XmlFile.prototype.write = function() {};
  */
 XmlFile.prototype.getLocalizedPath = function(locale) {
     var mapping = this.mapping || this.type.getMapping(this.pathName) || this.type.getDefaultMapping();
+    var spec = locale || this.project.sourceLocale;
+    if (mapping.localeMap && mapping.localeMap[spec]) {
+        spec = mapping.localeMap[spec];
+    }
+
     return path.normalize(this.API.utils.formatPath(mapping.template, {
         sourcepath: this.pathName,
-        locale: locale
+        locale: spec
     }));
 };
 

--- a/XmlFileType.js
+++ b/XmlFileType.js
@@ -32,7 +32,7 @@ var XmlFileType = function(project) {
     this.project = project;
     this.API = project.getAPI();
 
-    this.extensions = [ ".xml" ];
+    this.extensions = validExtensions;
 
     this.extracted = this.API.newTranslationSet(project.getSourceLocale());
     this.newres = this.API.newTranslationSet(project.getSourceLocale());

--- a/XmlFileType.js
+++ b/XmlFileType.js
@@ -299,7 +299,9 @@ XmlFileType.prototype.getDataType = function() {
 };
 
 XmlFileType.prototype.getResourceTypes = function() {
-    return {};
+    return {
+        "string": "ContextResourceString"
+    };
 };
 
 XmlFileType.prototype.getExtensions = function() {

--- a/XmlFileType.js
+++ b/XmlFileType.js
@@ -228,6 +228,40 @@ XmlFileType.prototype.getDefaultMapping = function() {
     return defaultMappings["**/*.xml"];
 };
 
+var validExtensions = [
+    ".xml",
+    ".ddi",
+    ".docm",
+    ".docx",
+    ".dotm",
+    ".gml",
+    ".iml",
+    ".mlt",
+    ".plist",
+    ".potm",
+    ".potx",
+    ".ppam",
+    ".ppsx",
+    ".pptm",
+    ".pptx",
+    ".properties",
+    ".qti",
+    ".sldx",
+    ".thmx",
+    ".uml",
+    ".webloc",
+    ".wsdl",
+    ".xlam",
+    ".xlm",
+    ".xlsb",
+    ".xlsm",
+    ".xlsx",
+    ".xmls",
+    ".xslt",
+    ".xspf",
+    ".xtml"
+];
+
 /**
  * Return true if the given path is an XML template file and is handled
  * by the current file type.
@@ -238,11 +272,11 @@ XmlFileType.prototype.getDefaultMapping = function() {
  */
 XmlFileType.prototype.handles = function(pathName) {
     // logger.debug("XmlFileType handles " + pathName + "?");
-    var ret = false;
+    if (!pathName) return false;
 
-    if (!ret) {
-        ret = pathName.length > 4 && pathName.substring(pathName.length - 4) === ".xml";
-    }
+    var lastdot = pathName.lastIndexOf(".");
+    var extension = pathName.substring(lastdot > -1 ? lastdot : 0);
+    var ret = validExtensions.indexOf(extension) > -1;
 
     // now match at least one of the mapping patterns
     if (ret) {
@@ -251,17 +285,17 @@ XmlFileType.prototype.handles = function(pathName) {
         var xmlSettings = this.project.settings.xml;
         var mappings = (xmlSettings && xmlSettings.mappings) ? xmlSettings.mappings : defaultMappings;
         var patterns = Object.keys(mappings);
-        ret = mm.isMatch(pathName, patterns);
 
-        // now check if it is an already-localized file, and if it has a different locale than the
-        // source locale, then we don't need to extract those strings
-        if (ret) {
-            for (var i = 0; i < patterns.length; i++) {
+        // now check if it has a mapping and if it is an already-localized file and if it has a different
+        // locale than the source locale, then we don't need to extract those strings
+        for (var i = 0; i < patterns.length; i++) {
+            if (mm.isMatch(pathName, patterns[i])) {
+                ret = true;
                 var locale = this.API.utils.getLocaleFromPath(mappings[patterns[i]].template, pathName);
                 if (locale && locale !== this.project.sourceLocale) {
                     ret = false;
-                    break;
                 }
+                break;
             }
         }
     }

--- a/XmlFileType.js
+++ b/XmlFileType.js
@@ -212,9 +212,10 @@ XmlFileType.prototype.getMapping = function(pathName) {
     var xmlSettings = this.project.settings.xml;
     var mappings = (xmlSettings && xmlSettings.mappings) ? xmlSettings.mappings : defaultMappings;
     var patterns = Object.keys(mappings);
+    var normalized = path.normalize(pathName);
 
     var match = patterns.find(function(pattern) {
-        return mm.isMatch(pathName, pattern);
+        return mm.isMatch(normalized, pattern);
     });
 
     return match && mappings[match];

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.10.0",
+        "ilib": "^14.11.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.11.0",
+        "ilib": "^14.11.1",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.15.0",
+        "loctool": "^2.16.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-xml",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "main": "./XmlFileType.js",
     "description": "A loctool plugin that knows how to localize xml files",
     "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         }
     ],
     "files": [
+        "schemas",
         "README.md",
         "LICENSE",
         "XmlFile.js",

--- a/schemas/android-resource-schema.json
+++ b/schemas/android-resource-schema.json
@@ -6,6 +6,7 @@
     "$defs": {
         "resource-attribute-type": {
             "type": "object",
+            "required": ["name"],
             "properties": {
                 "name": {
                     "type": "string",
@@ -41,6 +42,7 @@
         },
         "plural-item-type": {
             "type": "object",
+            "required": ["_text"],
             "properties": {
                 "_attributes": {
                     "type": "object",
@@ -88,6 +90,7 @@
             "type": "object",
             "localizable": true,
             "localizableType": "string",
+            "required": ["_text"],
             "properties": {
                 "_attributes": {
                     "$ref": "#/$defs/resource-attribute-type"
@@ -102,6 +105,7 @@
         },
         "array-item-type": {
             "type": "object",
+            "required": ["_text"],
             "properties": {
                 "_text": {
                     "type": "string",

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -2308,7 +2308,7 @@ module.exports.xmlfile = {
             type: t
         });
         test.ok(xf);
-        
+
         test.equal(xf.getLocalizedPath("de-DE"), "resources/de/arrays.xml");
         test.equal(xf.getLocalizedPath("fr-FR"), "resources/fr/arrays.xml");
         test.equal(xf.getLocalizedPath("en-001"), "resources/en/GB/arrays.xml");
@@ -2326,7 +2326,7 @@ module.exports.xmlfile = {
             type: t
         });
         test.ok(xf);
-        
+
         // non-mappings
         test.equal(xf.getLocalizedPath("da"), "resources/da/arrays.xml");
         test.equal(xf.getLocalizedPath("en-CA"), "resources/en/CA/arrays.xml");
@@ -2344,7 +2344,7 @@ module.exports.xmlfile = {
             type: t
         });
         test.ok(xf);
-        
+
         test.equal(xf.getLocalizedPath("de-DE"), "resources/values-de-rDE/strings.xml");
         test.equal(xf.getLocalizedPath("fr-FR"), "resources/values-fr-rFR/strings.xml");
         test.equal(xf.getLocalizedPath("en-001"), "resources/values-en-r001/strings.xml");

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -409,6 +409,75 @@ module.exports.xmlfile = {
         test.done();
     },
 
+    testXmlFileParseAllFields: function(test) {
+        test.expect(16);
+
+        var xf = new XmlFile({
+            project: p,
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<resources>\n' +
+            '    <string name="string 1" i18n="this is comment 1" locale="de-DE" context="fooasdf" formatted="true">this is string one</string>\n' +
+            '    <string name="string 2" i18n="this is comment 2" locale="zh-Hans-CN" context="badda bing" formatted="false">this is string two</string>\n' +
+            '</resources>\n'
+        );
+
+        var set = xf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+        var resources = set.getAll();
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getSource(), "this is string one");
+        test.equal(resources[0].getKey(), "string 1");
+        test.equal(resources[0].getComment(), "this is comment 1");
+        test.equal(resources[0].getSourceLocale(), "de-DE");
+        test.equal(resources[0].getContext(), "fooasdf");
+        test.ok(resources[0].formatted);
+
+        test.equal(resources[1].getSource(), "this is string two");
+        test.equal(resources[1].getKey(), "string 2");
+        test.equal(resources[1].getComment(), "this is comment 2");
+        test.equal(resources[1].getSourceLocale(), "zh-Hans-CN");
+        test.equal(resources[1].getContext(), "badda bing");
+        test.ok(!resources[1].formatted);
+
+        test.done();
+    },
+
+    testXmlFileParseNormalizeLocale: function(test) {
+        test.expect(7);
+
+        var xf = new XmlFile({
+            project: p,
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<resources>\n' +
+            '    <string name="string 1" locale="de_DE">this is string one</string>\n' +
+            '</resources>\n'
+        );
+
+        var set = xf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 1);
+        var resources = set.getAll();
+        test.equal(resources.length, 1);
+
+        test.equal(resources[0].getSource(), "this is string one");
+        test.equal(resources[0].getKey(), "string 1");
+        test.equal(resources[0].getSourceLocale(), "de-DE");
+
+        test.done();
+    },
+
     testXmlFileParseEscapeStringKeys: function(test) {
         test.expect(8);
 

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -108,7 +108,13 @@ var p = new CustomProject({
             "**/arrays.xml": {
                 "schema": "http://github.com/ilib-js/arrays.json",
                 "method": "copy",
-                "template": "resources/[localeDir]/arrays.xml"
+                "template": "resources/[localeDir]/arrays.xml",
+                "localeMap": {
+                    "de-DE": "de",
+                    "fr-FR": "fr",
+                    "sv-SE": "sv",
+                    "en-001": "en-GB"
+                }
             },
             "**/arrays-sparse.xml": {
                 "schema": "http://github.com/ilib-js/arrays.json",
@@ -2291,6 +2297,60 @@ module.exports.xmlfile = {
         test.done();
     },
 */
+
+    testXmlGetLocalizedPath: function(test) {
+        test.expect(4);
+
+        // mapping contains a locale map
+        var xf = new XmlFile({
+            project: p,
+            pathName: "./xml/arrays.xml",
+            type: t
+        });
+        test.ok(xf);
+        
+        test.equal(xf.getLocalizedPath("de-DE"), "resources/de/arrays.xml");
+        test.equal(xf.getLocalizedPath("fr-FR"), "resources/fr/arrays.xml");
+        test.equal(xf.getLocalizedPath("en-001"), "resources/en/GB/arrays.xml");
+
+        test.done();
+    },
+
+    testXmlGetLocalizedPathNonMapping: function(test) {
+        test.expect(3);
+
+        // mapping contains a locale map
+        var xf = new XmlFile({
+            project: p,
+            pathName: "./xml/arrays.xml",
+            type: t
+        });
+        test.ok(xf);
+        
+        // non-mappings
+        test.equal(xf.getLocalizedPath("da"), "resources/da/arrays.xml");
+        test.equal(xf.getLocalizedPath("en-CA"), "resources/en/CA/arrays.xml");
+
+        test.done();
+    },
+
+    testXmlGetLocalizedPathNoLocaleMap: function(test) {
+        test.expect(4);
+
+        // mapping does not contain a locale map
+        var xf = new XmlFile({
+            project: p,
+            pathName: "xml/values/strings.xml",
+            type: t
+        });
+        test.ok(xf);
+        
+        test.equal(xf.getLocalizedPath("de-DE"), "resources/values-de-rDE/strings.xml");
+        test.equal(xf.getLocalizedPath("fr-FR"), "resources/values-fr-rFR/strings.xml");
+        test.equal(xf.getLocalizedPath("en-001"), "resources/values-en-r001/strings.xml");
+
+        test.done();
+    },
 
     testXmlFileLocalize: function(test) {
         test.expect(7);

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -1389,7 +1389,46 @@ module.exports.xmlfile = {
         test.done();
     },
 
-    testXmlFileLocalizeWithEmptyString: function(test) {
+    testXmlFileLocalizeTextRemoveComments: function(test) {
+        test.expect(2);
+
+        var xf = new XmlFile({
+            project: p,
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<resources>\n' +
+            '    <string name="string 1"><!-- test1 -->this is string one</string>\n' +
+            '    <string name="string 2"><!-- test2 -->this is string two</string>\n' +
+            '</resources>\n'
+        );
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "this is string one",
+            sourceLocale: "en-US",
+            target: "C'est la chaîne numéro 1",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        var actual = xf.localizeText(translations, "fr-FR");
+        var expected =
+            '<resources>\n' +
+            '    <string name="string 1">C\'est la chaîne numéro 1</string>\n' +
+            '    <string name="string 2">this is string two</string>\n' +
+            '</resources>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXmlFileLocalizeWithEmptyStringInFile: function(test) {
         test.expect(2);
 
         var xf = new XmlFile({
@@ -1421,6 +1460,54 @@ module.exports.xmlfile = {
             '<resources>\n' +
             '    <string name="string 1">C\'est la chaîne numéro 1</string>\n' +
             '    <string name="string 2"/>\n' +
+            '</resources>\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+        test.done();
+    },
+
+    testXmlFileLocalizeTheEmptyString: function(test) {
+        test.expect(2);
+
+        var xf = new XmlFile({
+            project: p,
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<resources>\n' +
+            '    <string name="string 1">this is string one</string>\n' +
+            '    <string name="string 2"></string>\n' +
+            '</resources>\n'
+        );
+
+        var translations = new TranslationSet();
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 1",
+            source: "this is string one",
+            sourceLocale: "en-US",
+            target: "C'est la chaîne numéro 1",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+        translations.add(new ContextResourceString({
+            project: "foo",
+            key: "string 2",
+            source: "",
+            sourceLocale: "en-US",
+            target: "C'est la chaîne numéro 2",
+            targetLocale: "fr-FR",
+            datatype: "xml"
+        }));
+
+        var actual = xf.localizeText(translations, "fr-FR");
+        var expected =
+            '<resources>\n' +
+            '    <string name="string 1">C\'est la chaîne numéro 1</string>\n' +
+            '    <string name="string 2">C\'est la chaîne numéro 2</string>\n' +
             '</resources>\n';
 
         diff(actual, expected);

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -847,6 +847,106 @@ module.exports.xmlfile = {
         test.done();
     },
 
+    testXmlFileParseWithBasename: function(test) {
+        test.expect(8);
+
+        // when it's named messages.xml, it should apply the messages-schema schema
+        var xf = new XmlFile({
+            project: p,
+            pathName: "i18n/messages.xml",
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<messages>\n' +
+            '    <plurals name="foo">\n' +
+            '        <bar>\n' +
+            '            <one>singular</one>\n' +
+            '            <many>many</many>\n' +
+            '            <other>plural</other>\n' +
+            '        </bar>\n' +
+            '    </plurals>\n' +
+            '    <strings>\n' +
+            '        <a basename="testing the basename">b</a>\n' +
+            '        <c>d</c>\n' +
+            '    </strings>\n' +
+            '    <arrays>\n' +
+            '        <asdf i18n="comment">\n' +
+            '            <item>value 1</item>\n' +
+            '            <item>value 2</item>\n' +
+            '            <item>value 3</item>\n' +
+            '        </asdf>\n' +
+            '    </arrays>\n' +
+            '</messages>\n'
+        );
+
+        var set = xf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+        var resources = set.getAll();
+        test.equal(resources.length, 4);
+
+        test.equal(resources[1].getType(), "string");
+        test.equal(resources[1].getSource(), "b");
+        test.equal(resources[1].getKey(), "a");
+        // basename of the path to this xml file with no extensions
+        test.equal(resources[1].getContext(), "messages");
+
+        test.done();
+    },
+
+    testXmlFileParseWithPathname: function(test) {
+        test.expect(8);
+
+        // when it's named messages.xml, it should apply the messages-schema schema
+        var xf = new XmlFile({
+            project: p,
+            pathName: "i18n/messages.xml",
+            type: t
+        });
+        test.ok(xf);
+
+        xf.parse(
+            '<messages>\n' +
+            '    <plurals name="foo">\n' +
+            '        <bar>\n' +
+            '            <one>singular</one>\n' +
+            '            <many>many</many>\n' +
+            '            <other>plural</other>\n' +
+            '        </bar>\n' +
+            '    </plurals>\n' +
+            '    <strings>\n' +
+            '        <a pathname="testing the pathname">b</a>\n' +
+            '        <c>d</c>\n' +
+            '    </strings>\n' +
+            '    <arrays>\n' +
+            '        <asdf i18n="comment">\n' +
+            '            <item>value 1</item>\n' +
+            '            <item>value 2</item>\n' +
+            '            <item>value 3</item>\n' +
+            '        </asdf>\n' +
+            '    </arrays>\n' +
+            '</messages>\n'
+        );
+
+        var set = xf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 4);
+        var resources = set.getAll();
+        test.equal(resources.length, 4);
+
+        test.equal(resources[1].getType(), "string");
+        test.equal(resources[1].getSource(), "b");
+        test.equal(resources[1].getKey(), "a");
+        // the path to the file
+        test.equal(resources[1].getContext(), "i18n/messages.xml");
+
+        test.done();
+    },
+
     testXmlFileParseDeepRightSize: function(test) {
         test.expect(3);
 

--- a/test/testXmlFileType.js
+++ b/test/testXmlFileType.js
@@ -53,6 +53,21 @@ var p = new CustomProject({
                 "schema": "http://www.lge.com/xml/str",
                 "method": "copy",
                 "template": "[dir]/[localeDir]/str.xml"
+            },
+            "**/*.properties": {
+                "schema": "properties-schema",
+                "method": "copy",
+                "template": "[dir]/[localeDir]/[filename]"
+            },
+            "**/*.docx": {
+                "schema": "properties-schema",
+                "method": "copy",
+                "template": "[dir]/[localeDir]/[filename]"
+            },
+            "**/*.xlsx": {
+                "schema": "properties-schema",
+                "method": "copy",
+                "template": "[dir]/[localeDir]/[filename]"
             }
         }
     }
@@ -132,23 +147,30 @@ module.exports.xmlfiletype = {
     },
 
     testXmlFileTypeHandlesExtensionTrue: function(test) {
-        test.expect(2);
+        test.expect(5);
 
         var xft = new XmlFileType(p);
         test.ok(xft);
 
         test.ok(xft.handles("strings.xml"));
+        test.ok(xft.handles("strings.properties"));
+        test.ok(xft.handles("strings.xlsx"));
+        test.ok(xft.handles("strings.docx"));
 
         test.done();
     },
 
     testXmlFileTypeHandlesExtensionFalse: function(test) {
-        test.expect(2);
+        test.expect(4);
 
         var xft = new XmlFileType(p);
         test.ok(xft);
 
         test.ok(!xft.handles("strings.xmlhandle"));
+
+        // handled, but no mappings, so we don't read them
+        test.ok(!xft.handles("strings.uml"));
+        test.ok(!xft.handles("strings.iml"));
 
         test.done();
     },

--- a/test/testXmlFileType.js
+++ b/test/testXmlFileType.js
@@ -17,13 +17,18 @@
  * limitations under the License.
  */
 
+var path = require("path");
+
 if (!XmlFileType) {
     var XmlFileType = require("../XmlFileType.js");
     var CustomProject =  require("loctool/lib/CustomProject.js");
 }
 
 var p = new CustomProject({
-    sourceLocale: "en-US"
+    sourceLocale: "en-US",
+    plugins: [
+        path.join(process.cwd(), "XmlFileType")
+    ]
 }, "./testfiles", {
     locales:["en-GB"],
     xml: {
@@ -55,7 +60,10 @@ var p = new CustomProject({
 
 
 var p2 = new CustomProject({
-    sourceLocale: "en-US"
+    sourceLocale: "en-US",
+    plugins: [
+        path.join(process.cwd(), "XmlFileType")
+    ]
 }, "./testfiles", {
     locales:["en-GB"],
     xml: {

--- a/test/testfiles/schemas/arrays-schema.json
+++ b/test/testfiles/schemas/arrays-schema.json
@@ -7,6 +7,7 @@
     "$defs": {
         "array-item-type": {
             "type": "object",
+            "required": ["_text"],
             "properties": {
                 "_text": {
                     "type": "string",

--- a/test/testfiles/schemas/messages-schema.json
+++ b/test/testfiles/schemas/messages-schema.json
@@ -118,6 +118,18 @@
                             "localizableType": {
                                 "comment": "_value"
                             }
+                        },
+                        "basename": {
+                            "type": "string",
+                            "localizableType": {
+                                "context": "_basename"
+                            }
+                        },
+                        "pathname": {
+                            "type": "string",
+                            "localizableType": {
+                                "context": "_pathname"
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
- add support for Android flavors, which are associated with particular paths in the project. As such, these get specified in the mappings.
- add support for extracting the context & formatted fields of a resource from the XML, which are also used in Android files as well as other XML file types
- add the ability to assign the file path or just the base name of the file path to a field in the resource. The pathName is automatically set to the path previously, but now you can put it in a different field like "context" if necessary.
- add the ability to format the context, formatted, and flavor fields of a resource into a plural template
- support localeMaps in the mapping configuration