### PR TITLE
Add unit tests to verify the support for handling other types of xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1132,6 +1132,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.1.1
+
+- Add unit tests to verify parsing the file name with locale
+- Updated the way that the plugin decides which files to handle
+
 ### v1.1.0
 
 - Add support for new replacements and tags

--- a/XmlFileType.js
+++ b/XmlFileType.js
@@ -282,20 +282,12 @@ XmlFileType.prototype.handles = function(pathName) {
     if (ret) {
         ret = false;
         // first check if it is a source file
-        var xmlSettings = this.project.settings.xml;
-        var mappings = (xmlSettings && xmlSettings.mappings) ? xmlSettings.mappings : defaultMappings;
-        var patterns = Object.keys(mappings);
-
-        // now check if it has a mapping and if it is an already-localized file and if it has a different
-        // locale than the source locale, then we don't need to extract those strings
-        for (var i = 0; i < patterns.length; i++) {
-            if (mm.isMatch(pathName, patterns[i])) {
-                ret = true;
-                var locale = this.API.utils.getLocaleFromPath(mappings[patterns[i]].template, pathName);
-                if (locale && locale !== this.project.sourceLocale) {
-                    ret = false;
-                }
-                break;
+        var mapping = this.getMapping(pathName);
+        if (mapping) {
+            ret = true;
+            var locale = this.API.utils.getLocaleFromPath(mapping.template, pathName);
+            if (locale && locale !== this.project.sourceLocale) {
+                ret = false;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.16.1",
+        "loctool": "^2.16.2",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     },
     "devDependencies": {
         "assertextras": "^1.1.0",
-        "loctool": "^2.16.0",
+        "loctool": "^2.16.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-xml",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "main": "./XmlFileType.js",
     "description": "A loctool plugin that knows how to localize xml files",
     "license": "Apache-2.0",
@@ -54,6 +54,7 @@
     },
     "dependencies": {
         "ilib": "^14.11.1",
+        "log4js": "^6.3.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     },
     "dependencies": {
         "ilib": "^14.11.1",
-        "log4js": "^6.3.0",
         "xml-js": "^1.6.11"
     },
     "devDependencies": {

--- a/test/testXmlFile.js
+++ b/test/testXmlFile.js
@@ -408,7 +408,7 @@ module.exports.xmlfile = {
         test.equal(resources[0].getKey(), "string 1");
         test.equal(resources[0].getType(), "string");
 
-        test.ok(!resources[1].getSource());
+        test.equal(resources[1].getSource(), "");
         test.equal(resources[1].getKey(), "string 2");
         test.equal(resources[1].getType(), "string");
 

--- a/test/testXmlFileType.js
+++ b/test/testXmlFileType.js
@@ -57,17 +57,17 @@ var p = new CustomProject({
             "**/*.properties": {
                 "schema": "properties-schema",
                 "method": "copy",
-                "template": "[dir]/[localeDir]/[filename]"
+                "template": "[dir]/[basename]_[localeUnder].[extension]"
             },
             "**/*.docx": {
                 "schema": "properties-schema",
                 "method": "copy",
-                "template": "[dir]/[localeDir]/[filename]"
+                "template": "[dir]/[basename]_[locale].[extension]"
             },
             "**/*.xlsx": {
                 "schema": "properties-schema",
                 "method": "copy",
-                "template": "[dir]/[localeDir]/[filename]"
+                "template": "[dir]/[basename]_[locale].[extension]"
             }
         }
     }
@@ -220,18 +220,20 @@ module.exports.xmlfiletype = {
     },
 
     testXmlFileTypeHandlesTrueSourceLocale: function(test) {
-        test.expect(2);
+        test.expect(4);
 
         var xft = new XmlFileType(p);
         test.ok(xft);
 
         test.ok(xft.handles("resources/en/US/messages.xml"));
+        test.ok(xft.handles("resources/messages_en_US.properties"));
+        test.ok(xft.handles("file_en-US.docx"));
 
         test.done();
     },
 
     testXmlFileTypeHandlesAlreadyLocalizedGB: function(test) {
-        test.expect(2);
+        test.expect(4);
 
         var xft = new XmlFileType(p);
         test.ok(xft);
@@ -240,6 +242,8 @@ module.exports.xmlfiletype = {
         // not the source locale, so we don't need to
         // localize it again.
         test.ok(!xft.handles("resources/en/GB/messages.xml"));
+        test.ok(!xft.handles("props/messages_en_GB.properties"));
+        test.ok(!xft.handles("file_en-GB.docx"));
 
         test.done();
     },

--- a/test/testXmlFileType.js
+++ b/test/testXmlFileType.js
@@ -238,12 +238,12 @@ module.exports.xmlfiletype = {
         var xft = new XmlFileType(p);
         test.ok(xft);
 
-        // This matches one of the templates, but thge locale is
+        // This matches one of the templates, but the locale is
         // not the source locale, so we don't need to
         // localize it again.
         test.ok(!xft.handles("resources/en/GB/messages.xml"));
         test.ok(!xft.handles("props/messages_en_GB.properties"));
-        test.ok(!xft.handles("file_en-GB.docx"));
+        test.ok(!xft.handles("files/file_en-GB.docx"));
 
         test.done();
     },


### PR DESCRIPTION
- fixed the unit tests with a update to the FileType.handle() code
- also update some dependencies